### PR TITLE
Updates to get the server functioning with Iris

### DIFF
--- a/config/multer.js
+++ b/config/multer.js
@@ -6,7 +6,7 @@ const storage = multer.diskStorage({
     cb(null, './images/');
   },
   filename: (req, file, cb) => {
-    cb(null, `${Date.now()}-${file.originalname}`);
+    cb(null, `${file.originalname}`);
   },
 });
 

--- a/models/image.js
+++ b/models/image.js
@@ -4,7 +4,7 @@ const imageSchema = new mongoose.Schema({
   empty: Number,
   Pid: Number,
   Data: Number,
-  devID: Number,
+  devID: String,
   Type: String,
   sessionID: Number,
   Check: String,

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "mongoose": "^6.9.0",
     "multer": "^1.4.5-lts.1",
     "os": "^0.1.2",
+    "package.json": "^2.0.1",
     "qrcode": "^1.5.1",
     "supertest": "^6.3.3"
   }

--- a/routes/routes.js
+++ b/routes/routes.js
@@ -26,7 +26,12 @@ router.post("/sync_date", async (req, res) => {
     }
     res.json(lastSync);
   } catch (err) {
-    res.status(500).send(err.message);
+    res.statusMessage = err.message;
+    if(err.message==="No register found"){
+	res.status(404).end();
+    }else{
+    	res.status(500).end();
+    }
   }
 });
 
@@ -45,6 +50,7 @@ router.post('/images', multer.single('Image'), async (req, res) => {
     res.json({"state":"OK"});
   } catch (error) {
     console.log(error);
+    res.statusMessage = error.message;
     res.status(500).json({"ERROR":error})
   }
 });
@@ -65,7 +71,7 @@ router.post("/check", async (req, res) => {
     const { pid, sessionID, devID } = req.body;
     const images = await Image.find({ Pid:pid, sessionID, devID });
     const wanIp = await ImageService.getWanIp();
-    const imgs = images.map(image => wanIp+":"+port+image.Image).join(";");
+    const imgs = images.map(image => image.Image).join(";");
     res.json({ pid, imgs });
   } catch (error) {
     res.status(500).json({ message: error.message });

--- a/services/image.service.js
+++ b/services/image.service.js
@@ -34,7 +34,7 @@ const getWanIp = () => {
   let wanIp;
   for (const name of Object.keys(networkInts)) {
     for (const netInt of networkInts[name]) {
-      if (netInt.family === 'IPv4' && !netInt.internal) {
+      if (netInt.family === 'IPv4' && !netInt.internal && !name.includes("wg")) {
         wanIp = netInt.address;
         break;
       }

--- a/services/image.service.js
+++ b/services/image.service.js
@@ -34,7 +34,7 @@ const getWanIp = () => {
   let wanIp;
   for (const name of Object.keys(networkInts)) {
     for (const netInt of networkInts[name]) {
-      if (netInt.family === 'IPv4' && !netInt.internal && !name.includes("wg")) {
+      if (netInt.family === 'IPv4' && !netInt.internal && name.includes("wlp")) {
         wanIp = netInt.address;
         break;
       }
@@ -45,7 +45,7 @@ const getWanIp = () => {
 
 const syncDate = async (deviceID, providerID) => {
   try {
-    const lastRegister = await Image.findOne({ devID: deviceID, Pid: providerID }).sort({createdAt: -1});
+    const lastRegister = await Image.findOne({ devID: deviceID }).sort({Data: -1});
     if (!lastRegister) {
       throw new Error("No register found");
     }


### PR DESCRIPTION
While testing the server I ran into an issue where my Wireguard interface was being assigned to wanIP which generated QR codes with an unusable IP. This may not be incredibly important, as you will control the devices the server runs on, and those devices likely won't have wireguard interfaces. 

Excluding interfaces named wg, as those are typically wireguard interfaces which the Iris won't be able to connect to. Vmnet interfaces can still get through, however, I haven't had any trouble talking over these but it may be worthwhile to exclude them too. Another approach would be to be inclusive about which interfaces we want to return, like name.includes("wlp"). The biggest hurdle here is we won't ever know for certain what the wlan interface will be called, though standards dictate it should start with wlp there may be devices that don't follow that.